### PR TITLE
Feat: add support for third-party OpenAI-compatible API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ This project explores the use of agent-style capabilities (such as tool-use) to 
     OPENAI_API_KEY="<KEY>"
     ANTHROPIC_API_KEY="<KEY>"
     TORI_TASK_ID="<KEY>"
+    
+    # Optional: Use third-party OpenAI-compatible API endpoints
+    OPENAI_API_BASE="https://api.example.com/v1"
     ```
 
     For some tools, additional secrets are expected:

--- a/src/ageval/evaluators/agent/tools/code_interpreter.py
+++ b/src/ageval/evaluators/agent/tools/code_interpreter.py
@@ -99,8 +99,11 @@ class ToolCodeInterpreter(ToolBase):
         cls, *, text: str, prompt: str, model_name: str, debug: bool = False
     ) -> dict:
         from openai import OpenAI, RateLimitError
+        import os
 
-        client = OpenAI()
+        # Support custom base URLs via environment variable
+        base_url = os.environ.get("OPENAI_API_BASE")
+        client = OpenAI(base_url=base_url)
         content = f"For the prompt:\n```{prompt}\n```\nis the provided answer correct?\n```{text}\n```"
 
         @retry_with_exponential_backoff(

--- a/src/ageval/models/core.py
+++ b/src/ageval/models/core.py
@@ -118,13 +118,18 @@ def get_model(
 
     if model_provider == "openai":
         from langchain_openai import ChatOpenAI
+        import os
 
+        # Support custom base URLs via environment variable
+        base_url = os.environ.get("OPENAI_API_BASE")
+        
         langchain_model = ChatOpenAI(
             model=model_name,
             max_tokens=max_tokens,
             temperature=temp,
             model_kwargs=model_kwargs,
             max_retries=500,
+            base_url=base_url,
         )
     elif model_provider == "openai-assistant":
         from ageval.models.openai import AssistantModelOpenAI

--- a/src/ageval/models/openai.py
+++ b/src/ageval/models/openai.py
@@ -38,7 +38,10 @@ class AssistantModelOpenAI:
 
         logging.getLogger("httpx").setLevel(logging.WARNING)
 
-        self.client = openai.OpenAI()
+        # Support custom base URLs via environment variable
+        import os
+        base_url = os.environ.get("OPENAI_API_BASE")
+        self.client = openai.OpenAI(base_url=base_url)
         if tools is None:
             tools = (["search", "code_interpreter"],)
         tools_api = []

--- a/src/ageval/utils.py
+++ b/src/ageval/utils.py
@@ -11,7 +11,10 @@ DEFAULT_DOTENV_PATH = pathlib.Path("ageval_secrets.toml").absolute()
 
 
 def setup_api_keys(path: str = None):
-    """Tries to set up API keys based on local secrets file."""
+    """Tries to set up API keys based on local secrets file.
+    
+    Also supports custom OpenAI API base URLs via OPENAI_API_BASE variable.
+    """
 
     if path is None:
         path = DEFAULT_DOTENV_PATH
@@ -23,6 +26,10 @@ def setup_api_keys(path: str = None):
         verbose=True,
     ):
         logger.debug(f"Loaded API keys from '{path}'.")
+        
+        # If OPENAI_API_BASE is set in the file, ensure it's in environment
+        if "OPENAI_API_BASE" in os.environ:
+            logger.debug(f"Using custom OpenAI API base: {os.environ['OPENAI_API_BASE']}")
     else:
         logger.warning(
             f"No secrets file found at '{path}' or no variable set inside file. "


### PR DESCRIPTION
This commit adds flexible support for using third-party API providers that are compatible with OpenAI's API format.

**Changes:**

1. **Environment Variable Support**:
   - All OpenAI client initializations now respect the OPENAI_API_BASE environment variable
   - Allows users to specify custom base URLs for API endpoints

2. **Files Modified**:
   - src/ageval/models/core.py: ChatOpenAI langchain model initialization
   - src/ageval/models/openai.py: AssistantModelOpenAI client initialization
   - src/ageval/evaluators/agent/tools/code_interpreter.py: Code interpreter tool client
   - src/ageval/utils.py: Enhanced setup_api_keys with logging for custom base URLs

3. **Configuration**:
   - Users can now add OPENAI_API_BASE="https://api.example.com/v1" to ageval_secrets.toml
   - Maintains backward compatibility - if not set, uses OpenAI's default endpoint
   - Updated README with configuration examples

**Benefits:**
- Enables use of services like Azure OpenAI, Anthropic Claude via proxy, or other compatible providers
- Reduces API costs by allowing cheaper third-party providers
- Improves accessibility for users in regions with API restrictions
- No breaking changes to existing configurations