### PR TITLE
Fix: resolve LangChain pydantic v1 deprecation warning

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+</project>

--- a/src/ageval/evaluators/agent/core.py
+++ b/src/ageval/evaluators/agent/core.py
@@ -15,7 +15,7 @@ from ageval.evaluators.agent.tools.base import ToolBase
 import ageval.evaluators.agent.tools.fact_checking  # ensures fact checking tool registered
 import ageval.evaluators.agent.tools.code_interpreter  # import code_interpreter tool to register
 import ageval.evaluators.agent.tools.math_checker  # import math_checker tool to register
-from langchain_core.pydantic_v1 import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class PairwiseEvaluatorAgent(PairwiseEvaluator):

--- a/src/ageval/evaluators/agent/no_harm.py
+++ b/src/ageval/evaluators/agent/no_harm.py
@@ -1,7 +1,7 @@
 # For licensing see accompanying LICENSE file.
 # Copyright (C) 2025 Apple Inc. All Rights Reserved.
 from typing import Tuple
-from langchain_core.pydantic_v1 import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 from loguru import logger
 
 from ageval.constants import DEFAULT_OPENAI_MODEL

--- a/src/ageval/evaluators/agent/tools/base.py
+++ b/src/ageval/evaluators/agent/tools/base.py
@@ -1,6 +1,6 @@
 # For licensing see accompanying LICENSE file.
 # Copyright (C) 2025 Apple Inc. All Rights Reserved.
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic.v1 import BaseModel
 from typing import Type
 
 from ageval.experiments.config import PromptConfig

--- a/src/ageval/evaluators/agent/tools/code_interpreter.py
+++ b/src/ageval/evaluators/agent/tools/code_interpreter.py
@@ -8,7 +8,7 @@ Uses GPT-4o with code interpreter tool.
 """
 
 from typing import Type
-from langchain_core.pydantic_v1 import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from ageval.evaluators.agent.tools.base import ToolBase
 from ageval.evaluators.agent.tools.registry import register_tool

--- a/src/ageval/evaluators/agent/tools/fact_checking.py
+++ b/src/ageval/evaluators/agent/tools/fact_checking.py
@@ -10,7 +10,7 @@ Relevant docs: https://python.langchain.com/v0.2/docs/how_to/structured_output/#
 import os
 from typing import Type
 from loguru import logger
-from langchain_core.pydantic_v1 import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 from langchain_core.language_models import BaseChatModel
 
 import ageval.models

--- a/src/ageval/evaluators/agent/tools/math_checker.py
+++ b/src/ageval/evaluators/agent/tools/math_checker.py
@@ -6,7 +6,7 @@ A tool for checking math via GPT4o + code interpretation.
 """
 
 from typing import Type
-from langchain_core.pydantic_v1 import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from ageval.evaluators.agent.tools.code_interpreter import ToolCodeInterpreter
 from ageval.evaluators.agent.tools.registry import register_tool

--- a/src/ageval/evaluators/agent/tools/word_count.py
+++ b/src/ageval/evaluators/agent/tools/word_count.py
@@ -1,7 +1,7 @@
 # For licensing see accompanying LICENSE file.
 # Copyright (C) 2025 Apple Inc. All Rights Reserved.
 from typing import Type
-from langchain_core.pydantic_v1 import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 import ageval.models
 import ageval.external.web_search

--- a/src/ageval/models/dummy.py
+++ b/src/ageval/models/dummy.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from typing import Union
 import copy
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic.v1 import BaseModel
 from langchain_core.messages import AIMessage
 
 

--- a/src/ageval/models/openai.py
+++ b/src/ageval/models/openai.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2025 Apple Inc. All Rights Reserved.
 from typing import Optional, Union
 import openai
-from langchain_core.pydantic_v1 import BaseModel
+from pydantic.v1 import BaseModel
 from loguru import logger
 
 import ageval.models.utils


### PR DESCRIPTION
This commit addresses deprecation warnings from LangChain by updating pydantic imports to use the v1 compatibility namespace directly.

**Issue:**
LangChain Core 0.3.0+ uses pydantic v2 internally, and langchain_core.pydantic_v1 is deprecated. This was causing deprecation warnings throughout the codebase.

**Solution:**
Replace all occurrences of:
```python
from langchain_core.pydantic_v1 import BaseModel, Field
```

With:
```python
from pydantic.v1 import BaseModel, Field
```

**Files Updated:**
- src/ageval/models/openai.py
- src/ageval/models/dummy.py
- src/ageval/evaluators/agent/core.py
- src/ageval/evaluators/agent/no_harm.py
- src/ageval/evaluators/agent/tools/base.py
- src/ageval/evaluators/agent/tools/code_interpreter.py
- src/ageval/evaluators/agent/tools/fact_checking.py
- src/ageval/evaluators/agent/tools/math_checker.py
- src/ageval/evaluators/agent/tools/word_count.py

**Benefits:**
- Eliminates deprecation warnings during runtime
- Uses the recommended compatibility approach for mixed pydantic v1/v2 codebases
- Maintains backward compatibility
- No functional changes to existing code